### PR TITLE
Add vim key bindings hjkl

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 Llama — a terminal file manager.
 
-Why another file manager? I wanted something simple and minimalistic, 
-something to help me with faster navigation in the filesystem. A cd & 
-ls replacement. So I build "llama". It allows to quickly navigate 
+Why another file manager? I wanted something simple and minimalistic,
+something to help me with faster navigation in the filesystem. A cd &
+ls replacement. So I build "llama". It allows to quickly navigate
 with fuzzy searching; cd integration is quite simple. Open vim right
 from the llama. That's it. Simple and dumb as a llama.
 
@@ -35,17 +35,17 @@ process can't modify the working directory of the parent process.
 
 ## Usage
 
-| Key binding | Description     |
-|-------------|-----------------|
-| `Arrows`    | Move cursor     |
-| `Enter`     | Enter directory |
-| `Backspace` | Exit directory  |
-| `[A-Z]`     | Fuzzy search    |
-| `Esc`       | Exit with cd    |
-| `Ctrl+C`    | Exit with noop  |
+| Key binding        | Description                  |
+|--------------------|------------------------------|
+| `hjkl` or `Arrows` | Move cursor                  |
+| `Enter`            | Enter directory              |
+| `Backspace`        | Exit directory               |
+| `/[A-Z]`           | Fuzzy search                 |
+| `Esc`              | Exit search or Exit with cd  |
+| `Ctrl+C`           | Exit with noop               |
 
 Use `LLAMA_EDITOR` environment variable to specify program for opening files.
-The `EDITOR` variable also supported. 
+The `EDITOR` variable also supported.
 ```bash
 export LLAMA_EDITOR=vim
 ```

--- a/README.md
+++ b/README.md
@@ -35,20 +35,32 @@ process can't modify the working directory of the parent process.
 
 ## Usage
 
-| Key binding        | Description                  |
-|--------------------|------------------------------|
-| `hjkl` or `Arrows` | Move cursor                  |
-| `Enter`            | Enter directory              |
-| `Backspace`        | Exit directory               |
-| `/[A-Z]`           | Fuzzy search                 |
-| `Esc`              | Exit search or Exit with cd  |
-| `Ctrl+C`           | Exit with noop               |
+| Key binding | Description     |
+|-------------|-----------------|
+| `Arrows`    | Move cursor     |
+| `Enter`     | Enter directory |
+| `Backspace` | Exit directory  |
+| `[A-Z]`     | Fuzzy search    |
+| `Esc`       | Exit with cd    |
+| `Ctrl+C`    | Exit with noop  |
 
 Use `LLAMA_EDITOR` environment variable to specify program for opening files.
 The `EDITOR` variable also supported.
 ```bash
 export LLAMA_EDITOR=vim
 ```
+
+### Vim Keybindings
+
+Use `LLAMA_VIM_KEYBINDINGS` environment variable to enable vim keybindings.
+```bash
+export LLAMA_VIM_KEYBINDINGS=true
+```
+| Key binding | Description                 |
+|-------------|-----------------------------|
+| `hjkl`      | Move cursor                 |
+| `/[A-Z]`    | Fuzzy search                |
+| `Esc`       | Exit search or Exit with cd |
 
 ## License
 


### PR DESCRIPTION
Adds support for `hjkl`. Closes #2.

Fuzzy search mode is activated with `/` and deactivated with `Esc`. Changing directories also deactivates it.

For now, this is a breaking change. Making it configurable with `export LLAMA_VIM_KEYBINDINGS=true` seems to require multiple switch case statements, which is quite messy imo. Unless there is a better way?

Note: The git diff seems to have gone wonky after nesting the switch statement within an else.