### PR TITLE
Update install instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ from the llama. That's it. Simple and dumb as a llama.
 ## Install
 
 ```
-go get github.com/antonmedv/llama
+go install github.com/antonmedv/llama@latest
 ```
 
 Or download [prebuild binaries](https://github.com/antonmedv/llama/releases).


### PR DESCRIPTION
Just a tiny update to the installation instructions in the README for newer versions of Go.