### PR TITLE
Vim mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@
 
 Llama — a terminal file manager.
 
-Why another file manager? I wanted something simple and minimalistic, 
-something to help me with faster navigation in the filesystem. A cd & 
-ls replacement. So I build "llama". It allows to quickly navigate 
+Why another file manager? I wanted something simple and minimalistic,
+something to help me with faster navigation in the filesystem. A cd &
+ls replacement. So I build "llama". It allows to quickly navigate
 with fuzzy searching; cd integration is quite simple. Open vim right
 from the llama. That's it. Simple and dumb as a llama.
 
@@ -66,12 +66,29 @@ Note: we need a such helper as the child process can't modify the working direct
 | `Esc`       | Exit with cd    |
 | `Ctrl+C`    | Exit with noop  |
 
-
 The `EDITOR` or `LLAMA_EDITOR` environment variable used for openning files from the llama.
 
 ```bash
 export EDITOR=vim
 ```
+
+
+## Vim Mode
+
+Set `LLAMA_VIM_KEYBINDINGS=true` in the environment variable to enable vim
+keybindings. In Vim mode you'll need to press <kbd>/</kbd> to activate fuzzy
+search mode.
+
+ ```bash
+ export LLAMA_VIM_KEYBINDINGS=true
+ ```
+
+ | Key binding | Description             |
+ |-------------|-------------------------|
+ | `hjkl`      | Move cursor             |
+ | `/`         | Enter fuzzy search mode |
+ | `Esc`       | Exit fuzzy search mode  |
+
 
 ## License
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/antonmedv/llama
 go 1.17
 
 require (
+	github.com/charmbracelet/bubbles v0.14.0
 	github.com/charmbracelet/bubbletea v0.23.0
 	github.com/charmbracelet/lipgloss v0.6.0
 	github.com/sahilm/fuzzy v0.1.0
@@ -11,7 +12,6 @@ require (
 require (
 	github.com/aymanbagabas/go-osc52 v1.0.3 // indirect
 	github.com/containerd/console v1.0.3 // indirect
-	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/mattn/go-localereader v0.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,13 @@
+github.com/atotto/clipboard v0.1.4/go.mod h1:ZY9tmq7sm5xIbd9bOK4onWV4S6X0u6GY7Vn0Yu86PYI=
 github.com/aymanbagabas/go-osc52 v1.0.3 h1:DTwqENW7X9arYimJrPeGZcV0ln14sGMt3pHZspWD+Mg=
 github.com/aymanbagabas/go-osc52 v1.0.3/go.mod h1:zT8H+Rk4VSabYN90pWyugflM3ZhpTZNC7cASDfUCdT4=
+github.com/charmbracelet/bubbles v0.14.0 h1:DJfCwnARfWjZLvMglhSQzo76UZ2gucuHPy9jLWX45Og=
+github.com/charmbracelet/bubbles v0.14.0/go.mod h1:bbeTiXwPww4M031aGi8UK2HT9RDWoiNibae+1yCMtcc=
+github.com/charmbracelet/bubbletea v0.21.0/go.mod h1:GgmJMec61d08zXsOhqRC/AiOx4K4pmz+VIcRIm1FKr4=
 github.com/charmbracelet/bubbletea v0.23.0 h1:oGChhsNcm7kltiTdjxJbVlyh93N5fycluO7MsA2JEeg=
 github.com/charmbracelet/bubbletea v0.23.0/go.mod h1:JAfGK/3/pPKHTnAS8JIE2u9f61BjWTQY57RbT25aMXU=
+github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
+github.com/charmbracelet/lipgloss v0.5.0/go.mod h1:EZLha/HbzEt7cYqdFPovlqy5FZPj0xFhg5SaqxScmgs=
 github.com/charmbracelet/lipgloss v0.6.0 h1:1StyZB9vBSOyuZxQUcUwGr17JmojPNm87inij9N3wJY=
 github.com/charmbracelet/lipgloss v0.6.0/go.mod h1:tHh2wr34xcHjC2HCXIlGSG1jaDF0S0atAUvBMP6Ppuk=
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
@@ -22,12 +28,14 @@ github.com/mattn/go-runewidth v0.0.14 h1:+xnbZSEeDbOIg5/mE6JF0w6n9duR1l3/WmbinWV
 github.com/mattn/go-runewidth v0.0.14/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b h1:1XF24mVaiu7u+CFywTdcDo2ie1pzzhwjt6RHqzpMU34=
 github.com/muesli/ansi v0.0.0-20211018074035-2e021307bc4b/go.mod h1:fQuZ0gauxyBcmsdE3ZT4NasjaRdxmbCS0jRHsrWu3Ho=
+github.com/muesli/cancelreader v0.2.0/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/cancelreader v0.2.2 h1:3I4Kt4BQjOR54NavqnDogx/MIoWBFa0StPA8ELUXHmA=
 github.com/muesli/cancelreader v0.2.2/go.mod h1:3XuTXfFS2VjM+HTLZY9Ak0l6eUKfijIfMUZ4EgX0QYo=
 github.com/muesli/reflow v0.2.1-0.20210115123740-9e1d0d53df68/go.mod h1:Xk+z4oIWdQqJzsxyjgl3P22oYZnHdZ8FFTHAQQt5BMQ=
 github.com/muesli/reflow v0.3.0 h1:IFsN6K9NfGtjeggFP+68I4chLZV2yIKsXJFNZ+eWh6s=
 github.com/muesli/reflow v0.3.0/go.mod h1:pbwTDkVPibjO2kyvBQRBxTWEEGDGq0FlB1BIKtnHY/8=
 github.com/muesli/termenv v0.11.1-0.20220204035834-5ac8409525e0/go.mod h1:Bd5NYQ7pd+SrtBSrSNoBBmXlcY8+Xj4BMJgh8qcZrvs=
+github.com/muesli/termenv v0.11.1-0.20220212125758-44cd13922739/go.mod h1:Bd5NYQ7pd+SrtBSrSNoBBmXlcY8+Xj4BMJgh8qcZrvs=
 github.com/muesli/termenv v0.13.0 h1:wK20DRpJdDX8b7Ek2QfhvqhRQFZ237RGRO0RQ/Iqdy0=
 github.com/muesli/termenv v0.13.0/go.mod h1:sP1+uffeLaEYpyOTb8pLCUctGcGLnoFjSn4YJK5e2bc=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
@@ -39,6 +47,7 @@ golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220204135822-1c1b9b1eba6a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab h1:2QkjZIsXupsJbJIdSjjUOgWK3aEtzyuh2mPt3l/CkeU=
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 h1:JGgROgKl9N8DuW20oFS5gxc+lE67/N3FcwmBPMe7ArY=

--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	. "strings"
+	"text/tabwriter"
 	"time"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -68,23 +69,14 @@ func main() {
 		panic(err)
 	}
 
+	vimMode := lookup([]string{"LLAMA_VIM_KEYBINDINGS"}, "false") == "true"
+
 	if len(os.Args) == 2 {
 		// Show usage on --help.
 		if os.Args[1] == "--help" {
-			_, _ = fmt.Fprintln(os.Stderr, "\n  "+cursor.Render(" llama ")+`
-
-  Usage: llama [path]
-
-  Key bindings:
-    Arrows     Move cursor
-    Enter      Enter directory
-    Backspace  Exit directory
-    [A-Z]      Fuzzy search
-    Esc        Exit with cd
-    Ctrl+C     Exit with noop
-`)
-			os.Exit(1)
+			usage(vimMode)
 		}
+
 		// Maybe it is and argument, so get absolute path.
 		path, err = filepath.Abs(os.Args[1])
 		if err != nil {
@@ -92,7 +84,6 @@ func main() {
 		}
 	}
 
-	vimMode := lookup([]string{"LLAMA_VIM_KEYBINDINGS"}, "false") == "true"
 	keys := defaultKeymap
 	if vimMode {
 		keys = vimKeymap
@@ -115,6 +106,31 @@ func main() {
 		panic(err)
 	}
 	os.Exit(m.exitCode)
+}
+
+// Show usage and exit.
+func usage(vimMode bool) {
+	_, _ = fmt.Fprintln(os.Stderr, "\n  "+cursor.Render(" llama ")+"\n\n  Usage: llama [path]\n")
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 2, ' ', 0)
+
+	if vimMode {
+		fmt.Fprintln(w, "    hjkl\tMove cursor")
+	} else {
+		fmt.Fprintln(w, "    Arrows\tMove cursor")
+	}
+	fmt.Fprintln(w, "    Enter\tEnter directory")
+	fmt.Fprintln(w, "    Backspace\tExit directory")
+	if vimMode {
+		fmt.Fprintln(w, "    /\tEnter fuzzy match mode")
+		fmt.Fprintln(w, "    Esc\tExit fuzzy match mode (when active)")
+	}
+	fmt.Fprintln(w, "    [A-Z]\tFuzzy match")
+	fmt.Fprintln(w, "    Esc\tExit with cd")
+	fmt.Fprintln(w, "    Ctrl+C\tExit with noop")
+	w.Flush()
+	fmt.Print("\n")
+
+	os.Exit(1)
 }
 
 type model struct {


### PR DESCRIPTION
This update enables Vim keybindings when `LLAMA_VIM_KEYBINDINGS=true` is set.

Vim mode uses <kbd>hjkl</kbd> for navigation by default. Search-to-match can be activated with <kbd>/</kbd> and deactivated with <kbd>esc</kbd>. When search-to-match is active <kbd>esc</kbd> to quit is disabled and an indicator appears in the view.

This PR is based on https://github.com/antonmedv/llama/pull/8, however I'm implementing this separately because of the addition of the keymap (from [`Bubbles`](https://github.com/charmbracelet/bubbles#key)), which I believe simplifies the code.

Closes #2.