### PR TITLE
fix: index out of range

### DIFF
--- a/main.go
+++ b/main.go
@@ -644,7 +644,7 @@ func (m *model) saveCursorPosition() {
 
 func (m *model) fileName() (string, bool) {
 	i := m.c*m.rows + m.r
-	if i >= len(m.files) {
+	if i >= len(m.files) || i < 0 {
 		return "", false
 	}
 	return m.files[i].Name(), true


### PR DESCRIPTION
After pressing the arrow key in an empty directory, the array will go out of bounds when pressing the space

![image](https://user-images.githubusercontent.com/65269574/202963180-c0d21009-8649-48a7-91e6-fdef1486ae05.png)

press `->` or `<-` ...

![image](https://user-images.githubusercontent.com/65269574/202963329-b7f8b05f-044a-44ac-83b7-fcca9e441485.png)
