### PR TITLE
Add `--version` option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,8 @@ jobs:
         run: |
           set -x
           sed -i "s/version: .*/version: ${RELEASE_VERSION}/" snap/snapcraft.yaml
-          git add snap/snapcraft.yaml
+          sed -i "s/Version = .*/Version = \"${RELEASE_VERSION}\"/" main.go
+          git add snap/snapcraft.yaml main.go
           git config --global user.email "github-actions@github.com"
           git config --global user.name "github-actions"
           git commit -m "Release $RELEASE_VERSION"

--- a/main.go
+++ b/main.go
@@ -21,6 +21,8 @@ import (
 	"github.com/sahilm/fuzzy"
 )
 
+var Version = "v1.2.0"
+
 var (
 	warning = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).PaddingLeft(1).PaddingRight(1)
 	preview = lipgloss.NewStyle().PaddingLeft(2)
@@ -64,6 +66,10 @@ func main() {
 	if len(os.Args) == 2 {
 		if os.Args[1] == "--help" || os.Args[1] == "-h" {
 			usage()
+		}
+
+		if os.Args[1] == "--version" || os.Args[1] == "-v" {
+			version()
 		}
 
 		// Maybe it is and argument, so get absolute path.
@@ -746,6 +752,11 @@ func usage() {
 	put("    dd\tDelete file or dir")
 	_ = w.Flush()
 	_, _ = fmt.Fprintf(os.Stderr, "\n")
+	os.Exit(1)
+}
+
+func version() {
+	fmt.Fprintf(os.Stderr, "\n  %s %s\n\n", cursor.Render(" llama "), Version)
 	os.Exit(1)
 }
 


### PR DESCRIPTION
Hey,
Stumbled upon this repo and loved the concept. The lack of versioning bothered me as well as it did @mjsteinbaugh , so I added some.

It adds a `Version` variable that will update in CD.

If you were to build `llama` and want a different version than `dev`, either change `Version` in `main.go` or build again with flags:
```bash
$ go build -ldflags="-X main.Version=<version>"
```

Closes #34.