### PR TITLE
modify the location bar and filter bar display style

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"runtime"
 	. "strings"
 	"text/tabwriter"
 	"time"
@@ -24,12 +25,13 @@ import (
 var Version = "v1.2.0"
 
 var (
-	warning = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).PaddingLeft(1).PaddingRight(1)
-	preview = lipgloss.NewStyle().PaddingLeft(2)
-	cursor  = lipgloss.NewStyle().Background(lipgloss.Color("#825DF2")).Foreground(lipgloss.Color("#FFFFFF"))
-	bar     = lipgloss.NewStyle().Background(lipgloss.Color("#5C5C5C")).Foreground(lipgloss.Color("#FFFFFF"))
-	search  = lipgloss.NewStyle().Background(lipgloss.Color("#499F1C")).Foreground(lipgloss.Color("#FFFFFF"))
-	danger  = lipgloss.NewStyle().Background(lipgloss.Color("#FF0000")).Foreground(lipgloss.Color("#FFFFFF"))
+	warning       = lipgloss.NewStyle().Border(lipgloss.RoundedBorder()).PaddingLeft(1).PaddingRight(1)
+	preview       = lipgloss.NewStyle().PaddingLeft(2)
+	cursor        = lipgloss.NewStyle().Background(lipgloss.Color("#825DF2")).Foreground(lipgloss.Color("#FFFFFF"))
+	bar           = lipgloss.NewStyle().Background(lipgloss.Color("#5C5C5C")).Foreground(lipgloss.Color("#FFFFFF"))
+	search        = lipgloss.NewStyle().Background(lipgloss.Color("#499F1C")).Foreground(lipgloss.Color("#FFFFFF"))
+	danger        = lipgloss.NewStyle().Background(lipgloss.Color("#FF0000")).Foreground(lipgloss.Color("#FFFFFF"))
+	fileSeparator = string(filepath.Separator)
 )
 
 var (
@@ -406,7 +408,7 @@ start:
 				}
 				if m.files[n].IsDir() {
 					// Dirs should have a slash at the end.
-					name += "/"
+					name += fileSeparator
 				}
 				n++
 			}
@@ -484,11 +486,15 @@ start:
 	if userHomeDir, err := os.UserHomeDir(); err == nil {
 		location = Replace(m.path, userHomeDir, "~", 1)
 	}
+	if runtime.GOOS == "windows" {
+		location = ReplaceAll(Replace(location, "\\/", fileSeparator, 1), "/", fileSeparator)
+	}
 
 	// Filter bar (green).
 	filter := ""
 	if m.searchMode {
-		filter = "/" + m.search
+		location = TrimSuffix(location, fileSeparator)
+		filter = fileSeparator + m.search
 	}
 	barLen := len(location) + len(filter)
 	if barLen > outputWidth {


### PR DESCRIPTION
1. on windows replace `"\\/"` to `"\"` and replace `"/"` to `"\"`
2. on search mode, trim the original separator



<details>
<summary>Details</summary>

## windows

prev
![image](https://user-images.githubusercontent.com/65269574/204705752-a519af67-1c5c-45dd-97ce-72d09a308605.png)

now
![image](https://user-images.githubusercontent.com/65269574/204706051-d22ef1f4-c422-4567-91f6-10cdca52c1ae.png)

## linux

prev

![image](https://user-images.githubusercontent.com/65269574/204706531-bb02fb5f-59a2-484b-937c-50d73468b3f2.png)


now
![image](https://user-images.githubusercontent.com/65269574/204706572-d43a242e-9c69-4fde-9cb1-5c4dbb8ad830.png)

</details>

