### PR TITLE
Fix broken fish `ll` behaviour

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ function ll {
 
 ```fish
 function ll
-  set location (llama $argv); and cd $location;
+  set loc (llama $argv); and cd $loc;
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ function ll {
 
 ```fish
 function ll
-  cd (llama $argv);
+  set location (llama $argv); and cd $location;
 end
 ```
 


### PR DESCRIPTION
The suggested `ll` command for fish `cd`s into your home directory when pressing `Ctrl-c`.

Updated `README.md` with a fix for that.