### PR TITLE
Updated snapcraft 

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,20 +1,26 @@
 name: llama
-version: v1.2.0
+name: llama
+adopt-info: llama
 summary: Terminal JSON viewer
 description: Terminal JSON viewer
-base: core18
+base: core20
 grade: stable
 confinement: strict
+license: MIT
 
 apps:
   llama:
-    command: llama
+    command: bin/llama
     plugs: [home, network]
 
 parts:
   llama:
     plugin: go
     go-channel: 1.18/stable
-    source: .
+    source: https://github.com/antonmedv/llama
     source-type: git
     go-importpath: github.com/antonmedv/llama
+    
+    override-pull: |
+      snapcraftctl pull
+      snapcraftctl set-version "$(git describe --tags | sed 's/^v//')"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -19,7 +19,6 @@ parts:
     go-channel: 1.18/stable
     source: https://github.com/antonmedv/llama
     source-type: git
-    go-importpath: github.com/antonmedv/llama
     
     override-pull: |
       snapcraftctl pull


### PR DESCRIPTION
- Updated snap to core20
- added adopt-info to allow snapcraft to automatically set version of snap
- removed unneeded go import-path (core20 doesn't need it)
- added license info to snap
- added name to snap
- changed source to URL instead of "."